### PR TITLE
Now compatible with windows and python 3.5

### DIFF
--- a/keras_frcnn/data_generators.py
+++ b/keras_frcnn/data_generators.py
@@ -1,9 +1,9 @@
+from __future__ import absolute_import
 import numpy as np
 import cv2
 import random
 import copy
 from . import data_augment
-from . import roi_helpers
 import threading
 import itertools
 

--- a/keras_frcnn/data_generators.py
+++ b/keras_frcnn/data_generators.py
@@ -2,8 +2,8 @@ import numpy as np
 import cv2
 import random
 import copy
-import data_augment
-import roi_helpers
+from . import data_augment
+from . import roi_helpers
 import threading
 import itertools
 
@@ -75,7 +75,7 @@ class SampleSelector:
 		# ignore classes that have zero samples
 		self.classes = [b for b in class_count.keys() if class_count[b] > 0]
 		self.class_cycle = itertools.cycle(self.classes)
-		self.curr_class = self.class_cycle.next()
+		self.curr_class = next(self.class_cycle)
 
 	def skip_sample_for_balanced_class(self, img_data):
 
@@ -87,7 +87,7 @@ class SampleSelector:
 
 			if cls_name == self.curr_class:
 				class_in_img = True
-				self.curr_class = self.class_cycle.next()
+				self.curr_class = next(self.class_cycle)
 				break
 
 		if class_in_img:
@@ -132,12 +132,12 @@ def calc_rpn(C, img_data, width, height, resized_width, resized_height):
 	
 	# rpn ground truth
 
-	for anchor_size_idx in xrange(len(anchor_sizes)):
-		for anchor_ratio_idx in xrange(n_anchratios):
+	for anchor_size_idx in range(len(anchor_sizes)):
+		for anchor_ratio_idx in range(n_anchratios):
 			anchor_x = anchor_sizes[anchor_size_idx] * anchor_ratios[anchor_ratio_idx][0]
 			anchor_y = anchor_sizes[anchor_size_idx] * anchor_ratios[anchor_ratio_idx][1]	
 			
-			for ix in xrange(output_width):					
+			for ix in range(output_width):					
 				# x-coordinates of the current anchor box	
 				x1_anc = downscale * (ix + 0.5) - anchor_x / 2
 				x2_anc = downscale * (ix + 0.5) + anchor_x / 2	
@@ -146,7 +146,7 @@ def calc_rpn(C, img_data, width, height, resized_width, resized_height):
 				if x1_anc < 0 or x2_anc > resized_width:
 					continue
 					
-				for jy in xrange(output_height):
+				for jy in range(output_height):
 
 					# y-coordinates of the current anchor box
 					y1_anc = downscale * (jy + 0.5) - anchor_y / 2
@@ -163,7 +163,7 @@ def calc_rpn(C, img_data, width, height, resized_width, resized_height):
 					# note that this is different from the best IOU for a GT bbox
 					best_iou_for_loc = 0.0
 
-					for bbox_num in xrange(num_bboxes):
+					for bbox_num in range(num_bboxes):
 						
 						# get IOU of the current GT box and the current anchor box
 						curr_iou = iou([gta[bbox_num, 0], gta[bbox_num, 2], gta[bbox_num, 1], gta[bbox_num, 3]], [x1_anc, y1_anc, x2_anc, y2_anc])
@@ -218,7 +218,7 @@ def calc_rpn(C, img_data, width, height, resized_width, resized_height):
 
 	# we ensure that every bbox has at least one positive RPN region
 
-	for idx in xrange(num_anchors_for_bbox.shape[0]):
+	for idx in range(num_anchors_for_bbox.shape[0]):
 		if num_anchors_for_bbox[idx] == 0:
 			# no box with an IOU greater than zero ...
 			if best_anchor_for_bbox[idx, 0] == -1:
@@ -279,7 +279,7 @@ class threadsafe_iter:
 
 	def next(self):
 		with self.lock:
-			return self.it.next()		
+			return next(self.it)		
 
 	
 def threadsafe_generator(f):
@@ -291,7 +291,8 @@ def threadsafe_generator(f):
 
 def get_anchor_gt(all_img_data, class_count, C, backend, mode='train'):
 
-	all_img_data = sorted(all_img_data)
+	# The following line is not useful with Python 3.5, it is kept for the legacy
+	# all_img_data = sorted(all_img_data)
 
 	sample_selector = SampleSelector(class_count)
 
@@ -341,7 +342,7 @@ def get_anchor_gt(all_img_data, class_count, C, backend, mode='train'):
 				x_img = np.transpose(x_img, (2, 0, 1))
 				x_img = np.expand_dims(x_img, axis=0)
 
-				y_rpn_regr[:, y_rpn_regr.shape[1]/2:, :, :] *= C.std_scaling
+				y_rpn_regr[:, y_rpn_regr.shape[1]//2:, :, :] *= C.std_scaling
 
 				if backend == 'tf':
 					x_img = np.transpose(x_img, (0, 2, 3, 1))

--- a/keras_frcnn/roi_helpers.py
+++ b/keras_frcnn/roi_helpers.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pdb
 import math
-import data_generators
+from . import data_generators
 import copy
 
 

--- a/test_frcnn.py
+++ b/test_frcnn.py
@@ -42,18 +42,17 @@ C.rot_90 = False
 
 img_path = options.test_path
 
-
 def format_img(img, C):
 	img_min_side = float(C.im_size)
 	(height,width,_) = img.shape
 	
 	if width <= height:
-		f = img_min_side/width
-		new_height = int(f * height)
+		ratio = img_min_side/width
+		new_height = int(ratio * height)
 		new_width = int(img_min_side)
 	else:
-		f = img_min_side/height
-		new_width = int(f * width)
+		ratio = img_min_side/height
+		new_width = int(ratio * width)
 		new_height = int(img_min_side)
 	img = cv2.resize(img, (new_width, new_height), interpolation=cv2.INTER_CUBIC)
 	img = img[:, :, (2, 1, 0)]
@@ -64,8 +63,20 @@ def format_img(img, C):
 	img /= C.img_scaling_factor
 	img = np.transpose(img, (2, 0, 1))
 	img = np.expand_dims(img, axis=0)
-	return img
+	return img, ratio
 
+
+#
+# Method to transform the coordonates of the bounding box to its original size
+#
+def get_real_coordonates(ratio, x1, y1, x2, y2):
+
+	real_x1 = x1 // ratio
+	real_y1 = y1 // ratio
+	real_x2 = x2 // ratio 
+	real_y2 = y2 // ratio 
+
+	return (real_x1, real_y1, real_x2, real_y2)
 
 class_mapping = C.class_mapping
 
@@ -126,7 +137,7 @@ for idx, img_name in enumerate(sorted(os.listdir(img_path))):
 
 	img = cv2.imread(filepath)
 
-	X = format_img(img, C)
+	X, ratio = format_img(img, C)
 
 	img_scaled = np.transpose(X.copy()[0, (2, 1, 0), :, :], (1, 2, 0)).copy()
 	img_scaled[:, :, 0] += 123.68
@@ -196,6 +207,7 @@ for idx, img_name in enumerate(sorted(os.listdir(img_path))):
 
 	all_dets = []
 
+
 	for key in bboxes:
 		bbox = np.array(bboxes[key])
 
@@ -203,19 +215,22 @@ for idx, img_name in enumerate(sorted(os.listdir(img_path))):
 		for jk in range(new_boxes.shape[0]):
 			(x1, y1, x2, y2) = new_boxes[jk,:]
 
-			cv2.rectangle(img_scaled,(x1, y1), (x2, y2), (int(class_to_color[key][0]), int(class_to_color[key][1]), int(class_to_color[key][2])),2)
+			(real_x1, real_y1, real_x2, real_y2) = get_real_coordonates(ratio, x1, y1, x2, y2)
+
+			cv2.rectangle(img,(real_x1, real_y1), (real_x2, real_y2), (int(class_to_color[key][0]), int(class_to_color[key][1]), int(class_to_color[key][2])),2)
 
 			textLabel = '{}: {}'.format(key,int(100*new_probs[jk]))
 			all_dets.append((key,100*new_probs[jk]))
 
 			(retval,baseLine) = cv2.getTextSize(textLabel,cv2.FONT_HERSHEY_COMPLEX,1,1)
-			textOrg = (x1, y1-0)
+			textOrg = (real_x1, real_y1-0)
 
-			cv2.rectangle(img_scaled, (textOrg[0] - 5, textOrg[1]+baseLine - 5), (textOrg[0]+retval[0] + 5, textOrg[1]-retval[1] - 5), (0, 0, 0), 2)
-			cv2.rectangle(img_scaled, (textOrg[0] - 5,textOrg[1]+baseLine - 5), (textOrg[0]+retval[0] + 5, textOrg[1]-retval[1] - 5), (255, 255, 255), -1)
-			cv2.putText(img_scaled, textLabel, textOrg, cv2.FONT_HERSHEY_DUPLEX, 1, (0, 0, 0), 1)
+			cv2.rectangle(img, (textOrg[0] - 5, textOrg[1]+baseLine - 5), (textOrg[0]+retval[0] + 5, textOrg[1]-retval[1] - 5), (0, 0, 0), 2)
+			cv2.rectangle(img, (textOrg[0] - 5,textOrg[1]+baseLine - 5), (textOrg[0]+retval[0] + 5, textOrg[1]-retval[1] - 5), (255, 255, 255), -1)
+			cv2.putText(img, textLabel, textOrg, cv2.FONT_HERSHEY_DUPLEX, 1, (0, 0, 0), 1)
+
 	print('Elapsed time = {}'.format(time.time() - st))
 	#cv2.imshow('img', img_scaled)
 	#cv2.waitKey(0)
-	cv2.imwrite('./results_imgs/{}.png'.format(idx),img_scaled)
+	cv2.imwrite('./results_imgs/{}.png'.format(idx),img)
 	print(all_dets)

--- a/test_frcnn.py
+++ b/test_frcnn.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import os
 import cv2
 import numpy as np
@@ -31,7 +32,7 @@ if not options.test_path:   # if filename is not given
 
 config_output_filename = options.config_filename
 
-with open(config_output_filename, 'r') as f_in:
+with open(config_output_filename, 'rb') as f_in:
 	C = pickle.load(f_in)
 
 # turn off any data augmentation at test time
@@ -71,7 +72,7 @@ class_mapping = C.class_mapping
 if 'bg' not in class_mapping:
 	class_mapping['bg'] = len(class_mapping)
 
-class_mapping = {v: k for k, v in class_mapping.iteritems()}
+class_mapping = {v: k for k, v in class_mapping.items()}
 print(class_mapping)
 class_to_color = {class_mapping[v]: np.random.randint(0, 255, 3) for v in class_mapping}
 C.num_rois = int(options.num_rois)
@@ -202,7 +203,7 @@ for idx, img_name in enumerate(sorted(os.listdir(img_path))):
 		for jk in range(new_boxes.shape[0]):
 			(x1, y1, x2, y2) = new_boxes[jk,:]
 
-			cv2.rectangle(img_scaled,(x1, y1), (x2, y2), class_to_color[key],2)
+			cv2.rectangle(img_scaled,(x1, y1), (x2, y2), (int(class_to_color[key][0]), int(class_to_color[key][1]), int(class_to_color[key][2])),2)
 
 			textLabel = '{}: {}'.format(key,int(100*new_probs[jk]))
 			all_dets.append((key,100*new_probs[jk]))
@@ -214,7 +215,7 @@ for idx, img_name in enumerate(sorted(os.listdir(img_path))):
 			cv2.rectangle(img_scaled, (textOrg[0] - 5,textOrg[1]+baseLine - 5), (textOrg[0]+retval[0] + 5, textOrg[1]-retval[1] - 5), (255, 255, 255), -1)
 			cv2.putText(img_scaled, textLabel, textOrg, cv2.FONT_HERSHEY_DUPLEX, 1, (0, 0, 0), 1)
 	print('Elapsed time = {}'.format(time.time() - st))
-	cv2.imshow('img', img_scaled)
-	cv2.waitKey(0)
-	#cv2.imwrite('./imgs/{}.png'.format(idx),img_scaled)
+	#cv2.imshow('img', img_scaled)
+	#cv2.waitKey(0)
+	cv2.imwrite('./results_imgs/{}.png'.format(idx),img_scaled)
 	print(all_dets)

--- a/train_frcnn.py
+++ b/train_frcnn.py
@@ -197,10 +197,10 @@ for epoch_num in range(num_epochs):
 			rpn_accuracy_for_epoch.append((len(pos_samples)))
 
 			if C.num_rois > 1:
-				if len(pos_samples) < C.num_rois/2:
+				if len(pos_samples) < C.num_rois//2:
 					selected_pos_samples = pos_samples.tolist()
 				else:
-					selected_pos_samples = np.random.choice(pos_samples, C.num_rois/2, replace=False).tolist()
+					selected_pos_samples = np.random.choice(pos_samples, C.num_rois//2, replace=False).tolist()
 				try:
 					selected_neg_samples = np.random.choice(neg_samples, C.num_rois - len(selected_pos_samples), replace=False).tolist()
 				except:

--- a/train_frcnn.py
+++ b/train_frcnn.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import random
 import pprint
 import sys
@@ -69,7 +70,7 @@ if 'bg' not in classes_count:
 
 C.class_mapping = class_mapping
 
-inv_map = {v: k for k, v in class_mapping.iteritems()}
+inv_map = {v: k for k, v in class_mapping.items()}
 
 print('Training images per class:')
 pprint.pprint(classes_count)
@@ -77,7 +78,7 @@ print('Num classes (including bg) = {}'.format(len(classes_count)))
 
 config_output_filename = options.config_filename
 
-with open(config_output_filename, 'w') as config_f:
+with open(config_output_filename, 'wb') as config_f:
 	pickle.dump(C,config_f)
 	print('Config has been written to {}, and can be loaded when testing to ensure correct results'.format(config_output_filename))
 
@@ -145,7 +146,7 @@ start_time = time.time()
 
 best_loss = np.Inf
 
-class_mapping_inv = {v: k for k, v in class_mapping.iteritems()}
+class_mapping_inv = {v: k for k, v in class_mapping.items()}
 print('Starting training')
 
 
@@ -163,7 +164,7 @@ for epoch_num in range(num_epochs):
 				if mean_overlapping_bboxes == 0:
 					print('RPN is not producing bounding boxes that overlap the ground truth boxes. Check RPN settings or keep training.')
 
-			X, Y, img_data = data_gen_train.next()
+			X, Y, img_data = next(data_gen_train)
 
 			loss_rpn = model_rpn.train_on_batch(X, Y)
 


### PR DESCRIPTION
Compatibility with Python 3.5 on windows.

- Change xrange to range in data_generator.py
- Change iteritem to item in train_frcnn.py and test_frcnn.py
- Use floor division line 345 in data_generator.py
- Change import "file" to from . import "file"
- Rectified to drawing of the rectangle inside test_frcnn.py
- change data.next() to next(data) everywhere
- Change the open mode of the file from text to binary ('w' and 'r' to 'wb' and 'rb')