### PR TITLE
vgg.py: floating point -> floor division in get_img_output_length

### DIFF
--- a/keras_frcnn/vgg.py
+++ b/keras_frcnn/vgg.py
@@ -28,7 +28,7 @@ def get_weight_path():
 
 def get_img_output_length(width, height):
     def get_output_length(input_length):
-        return input_length/16
+        return input_length//16
 
     return get_output_length(width), get_output_length(height)    
 

--- a/keras_frcnn/vgg.py
+++ b/keras_frcnn/vgg.py
@@ -5,6 +5,7 @@
 """
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 
 import warnings
 


### PR DESCRIPTION
Exchanged floating point for floor division to yield integer valued image dimensions. 
This had caused a freeze in `train_frcnn.py` for me through line 181 `next(data_gen_train)` coming through `get_anchor_gt(...)` and ultimately `calc_rpn(...)`.